### PR TITLE
Add locale to RFC date formatter.

### DIFF
--- a/Muon/String+Muon.swift
+++ b/Muon/String+Muon.swift
@@ -15,6 +15,7 @@ public extension String {
 
         let dateFormatter = NSDateFormatter()
         dateFormatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
 
         let dateFromFormat : (String) -> NSDate? = {formatString in
             dateFormatter.dateFormat = formatString
@@ -49,6 +50,7 @@ public extension String {
 
         let dateFormatter = NSDateFormatter()
         dateFormatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
 
         let dateFromFormat : (String) -> NSDate? = {formatString in
             dateFormatter.dateFormat = formatString


### PR DESCRIPTION
Add a locale to NSDateFormatter to set up a time- and system-invariant base for date parsing.
(See this technote: https://developer.apple.com/library/ios/qa/qa1480/_index.html)